### PR TITLE
added network names, fixed networkId of contract, small refactor

### DIFF
--- a/contracts/BlankArt.js
+++ b/contracts/BlankArt.js
@@ -1,980 +1,980 @@
 const BlankArt = {
-  network: "homestead",
+  networkId: 1,
   address: "0x9ef14cC7C558a70FBB6480CE58042feebAA1972E",
   abi: [
     {
-      "type": "constructor",
-      "inputs": [
+      type: "constructor",
+      inputs: [
         {
-          "name": "_foundationAddress",
-          "type": "address",
-          "internalType": "address payable"
+          name: "_foundationAddress",
+          type: "address",
+          internalType: "address payable",
         },
         {
-          "name": "_signer",
-          "type": "address",
-          "internalType": "address"
+          name: "_signer",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "_maxTokenSupply",
-          "type": "uint256",
-          "internalType": "uint256"
+          name: "_maxTokenSupply",
+          type: "uint256",
+          internalType: "uint256",
         },
         {
-          "name": "baseURI",
-          "type": "string",
-          "internalType": "string"
+          name: "baseURI",
+          type: "string",
+          internalType: "string",
         },
         {
-          "name": "_royaltyBPS",
-          "type": "uint16",
-          "internalType": "uint16"
-        }
+          name: "_royaltyBPS",
+          type: "uint16",
+          internalType: "uint16",
+        },
       ],
-      "stateMutability": "nonpayable"
+      stateMutability: "nonpayable",
     },
     {
-      "name": "Approval",
-      "type": "event",
-      "inputs": [
+      name: "Approval",
+      type: "event",
+      inputs: [
         {
-          "name": "owner",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
+          name: "owner",
+          type: "address",
+          indexed: true,
+          internalType: "address",
         },
         {
-          "name": "approved",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
+          name: "approved",
+          type: "address",
+          indexed: true,
+          internalType: "address",
         },
         {
-          "name": "tokenId",
-          "type": "uint256",
-          "indexed": true,
-          "internalType": "uint256"
-        }
+          name: "tokenId",
+          type: "uint256",
+          indexed: true,
+          internalType: "uint256",
+        },
       ],
-      "anonymous": false
+      anonymous: false,
     },
     {
-      "name": "ApprovalForAll",
-      "type": "event",
-      "inputs": [
+      name: "ApprovalForAll",
+      type: "event",
+      inputs: [
         {
-          "name": "owner",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
+          name: "owner",
+          type: "address",
+          indexed: true,
+          internalType: "address",
         },
         {
-          "name": "operator",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
+          name: "operator",
+          type: "address",
+          indexed: true,
+          internalType: "address",
         },
         {
-          "name": "approved",
-          "type": "bool",
-          "indexed": false,
-          "internalType": "bool"
-        }
+          name: "approved",
+          type: "bool",
+          indexed: false,
+          internalType: "bool",
+        },
       ],
-      "anonymous": false
+      anonymous: false,
     },
     {
-      "name": "BaseTokenUriUpdated",
-      "type": "event",
-      "inputs": [
+      name: "BaseTokenUriUpdated",
+      type: "event",
+      inputs: [
         {
-          "name": "baseTokenURI",
-          "type": "string",
-          "indexed": false,
-          "internalType": "string"
-        }
+          name: "baseTokenURI",
+          type: "string",
+          indexed: false,
+          internalType: "string",
+        },
       ],
-      "anonymous": false
+      anonymous: false,
     },
     {
-      "name": "BlankRoyaltySet",
-      "type": "event",
-      "inputs": [
+      name: "BlankRoyaltySet",
+      type: "event",
+      inputs: [
         {
-          "name": "recipient",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
+          name: "recipient",
+          type: "address",
+          indexed: false,
+          internalType: "address",
         },
         {
-          "name": "bps",
-          "type": "uint16",
-          "indexed": false,
-          "internalType": "uint16"
-        }
+          name: "bps",
+          type: "uint16",
+          indexed: false,
+          internalType: "uint16",
+        },
       ],
-      "anonymous": false
+      anonymous: false,
     },
     {
-      "name": "FoundationAddressUpdated",
-      "type": "event",
-      "inputs": [
+      name: "FoundationAddressUpdated",
+      type: "event",
+      inputs: [
         {
-          "name": "foundationAddress",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
-        }
+          name: "foundationAddress",
+          type: "address",
+          indexed: false,
+          internalType: "address",
+        },
       ],
-      "anonymous": false
+      anonymous: false,
     },
     {
-      "name": "Initialized",
-      "type": "event",
-      "inputs": [
+      name: "Initialized",
+      type: "event",
+      inputs: [
         {
-          "name": "controller",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
+          name: "controller",
+          type: "address",
+          indexed: false,
+          internalType: "address",
         },
         {
-          "name": "signer",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
+          name: "signer",
+          type: "address",
+          indexed: false,
+          internalType: "address",
         },
         {
-          "name": "baseURI",
-          "type": "string",
-          "indexed": false,
-          "internalType": "string"
+          name: "baseURI",
+          type: "string",
+          indexed: false,
+          internalType: "string",
         },
         {
-          "name": "mintPrice",
-          "type": "uint256",
-          "indexed": false,
-          "internalType": "uint256"
+          name: "mintPrice",
+          type: "uint256",
+          indexed: false,
+          internalType: "uint256",
         },
         {
-          "name": "maxTokenSupply",
-          "type": "uint256",
-          "indexed": false,
-          "internalType": "uint256"
+          name: "maxTokenSupply",
+          type: "uint256",
+          indexed: false,
+          internalType: "uint256",
         },
         {
-          "name": "active",
-          "type": "bool",
-          "indexed": false,
-          "internalType": "bool"
+          name: "active",
+          type: "bool",
+          indexed: false,
+          internalType: "bool",
         },
         {
-          "name": "publicMint",
-          "type": "bool",
-          "indexed": false,
-          "internalType": "bool"
-        }
+          name: "publicMint",
+          type: "bool",
+          indexed: false,
+          internalType: "bool",
+        },
       ],
-      "anonymous": false
+      anonymous: false,
     },
     {
-      "name": "Minted",
-      "type": "event",
-      "inputs": [
+      name: "Minted",
+      type: "event",
+      inputs: [
         {
-          "name": "tokenId",
-          "type": "uint256",
-          "indexed": false,
-          "internalType": "uint256"
+          name: "tokenId",
+          type: "uint256",
+          indexed: false,
+          internalType: "uint256",
         },
         {
-          "name": "member",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
+          name: "member",
+          type: "address",
+          indexed: false,
+          internalType: "address",
         },
         {
-          "name": "tokenURI",
-          "type": "string",
-          "indexed": false,
-          "internalType": "string"
-        }
+          name: "tokenURI",
+          type: "string",
+          indexed: false,
+          internalType: "string",
+        },
       ],
-      "anonymous": false
+      anonymous: false,
     },
     {
-      "name": "OwnershipTransferred",
-      "type": "event",
-      "inputs": [
+      name: "OwnershipTransferred",
+      type: "event",
+      inputs: [
         {
-          "name": "previousOwner",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
+          name: "previousOwner",
+          type: "address",
+          indexed: true,
+          internalType: "address",
         },
         {
-          "name": "newOwner",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
-        }
+          name: "newOwner",
+          type: "address",
+          indexed: true,
+          internalType: "address",
+        },
       ],
-      "anonymous": false
+      anonymous: false,
     },
     {
-      "name": "PermanentURI",
-      "type": "event",
-      "inputs": [
+      name: "PermanentURI",
+      type: "event",
+      inputs: [
         {
-          "name": "_value",
-          "type": "string",
-          "indexed": false,
-          "internalType": "string"
+          name: "_value",
+          type: "string",
+          indexed: false,
+          internalType: "string",
         },
         {
-          "name": "_id",
-          "type": "uint256",
-          "indexed": true,
-          "internalType": "uint256"
-        }
+          name: "_id",
+          type: "uint256",
+          indexed: true,
+          internalType: "uint256",
+        },
       ],
-      "anonymous": false
+      anonymous: false,
     },
     {
-      "name": "Transfer",
-      "type": "event",
-      "inputs": [
+      name: "Transfer",
+      type: "event",
+      inputs: [
         {
-          "name": "from",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
+          name: "from",
+          type: "address",
+          indexed: true,
+          internalType: "address",
         },
         {
-          "name": "to",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
+          name: "to",
+          type: "address",
+          indexed: true,
+          internalType: "address",
         },
         {
-          "name": "tokenId",
-          "type": "uint256",
-          "indexed": true,
-          "internalType": "uint256"
-        }
+          name: "tokenId",
+          type: "uint256",
+          indexed: true,
+          internalType: "uint256",
+        },
       ],
-      "anonymous": false
+      anonymous: false,
     },
     {
-      "name": "VoucherSignersUpdated",
-      "type": "event",
-      "inputs": [
+      name: "VoucherSignersUpdated",
+      type: "event",
+      inputs: [
         {
-          "name": "foundationAddress",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
+          name: "foundationAddress",
+          type: "address",
+          indexed: false,
+          internalType: "address",
         },
         {
-          "name": "active",
-          "type": "bool",
-          "indexed": false,
-          "internalType": "bool"
-        }
+          name: "active",
+          type: "bool",
+          indexed: false,
+          internalType: "bool",
+        },
       ],
-      "anonymous": false
+      anonymous: false,
     },
     {
-      "name": "active",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "active",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "bool",
-          "internalType": "bool"
-        }
+          name: "",
+          type: "bool",
+          internalType: "bool",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "addBaseURI",
-      "type": "function",
-      "inputs": [
+      name: "addBaseURI",
+      type: "function",
+      inputs: [
         {
-          "name": "baseURI",
-          "type": "string",
-          "internalType": "string"
-        }
+          name: "baseURI",
+          type: "string",
+          internalType: "string",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "addVoucherSigner",
-      "type": "function",
-      "inputs": [
+      name: "addVoucherSigner",
+      type: "function",
+      inputs: [
         {
-          "name": "newVoucherSigner",
-          "type": "address",
-          "internalType": "address"
-        }
+          name: "newVoucherSigner",
+          type: "address",
+          internalType: "address",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "approve",
-      "type": "function",
-      "inputs": [
+      name: "approve",
+      type: "function",
+      inputs: [
         {
-          "name": "to",
-          "type": "address",
-          "internalType": "address"
+          name: "to",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "tokenId",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "tokenId",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "availableToWithdraw",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "availableToWithdraw",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "balanceOf",
-      "type": "function",
-      "inputs": [
+      name: "balanceOf",
+      type: "function",
+      inputs: [
         {
-          "name": "owner",
-          "type": "address",
-          "internalType": "address"
-        }
+          name: "owner",
+          type: "address",
+          internalType: "address",
+        },
       ],
-      "outputs": [
+      outputs: [
         {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "blankRoyalty",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "blankRoyalty",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "recipient",
-          "type": "address",
-          "internalType": "address"
+          name: "recipient",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "bps",
-          "type": "uint24",
-          "internalType": "uint24"
-        }
+          name: "bps",
+          type: "uint24",
+          internalType: "uint24",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "foundationAddress",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "foundationAddress",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "address",
-          "internalType": "address payable"
-        }
+          name: "",
+          type: "address",
+          internalType: "address payable",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "getApproved",
-      "type": "function",
-      "inputs": [
+      name: "getApproved",
+      type: "function",
+      inputs: [
         {
-          "name": "tokenId",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "tokenId",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "outputs": [
+      outputs: [
         {
-          "name": "",
-          "type": "address",
-          "internalType": "address"
-        }
+          name: "",
+          type: "address",
+          internalType: "address",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "getChainID",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "getChainID",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "isApprovedForAll",
-      "type": "function",
-      "inputs": [
+      name: "isApprovedForAll",
+      type: "function",
+      inputs: [
         {
-          "name": "owner",
-          "type": "address",
-          "internalType": "address"
+          name: "owner",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "operator",
-          "type": "address",
-          "internalType": "address"
-        }
+          name: "operator",
+          type: "address",
+          internalType: "address",
+        },
       ],
-      "outputs": [
+      outputs: [
         {
-          "name": "",
-          "type": "bool",
-          "internalType": "bool"
-        }
+          name: "",
+          type: "bool",
+          internalType: "bool",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "isMember",
-      "type": "function",
-      "inputs": [
+      name: "isMember",
+      type: "function",
+      inputs: [
         {
-          "name": "account",
-          "type": "address",
-          "internalType": "address"
-        }
+          name: "account",
+          type: "address",
+          internalType: "address",
+        },
       ],
-      "outputs": [
+      outputs: [
         {
-          "name": "",
-          "type": "bool",
-          "internalType": "bool"
-        }
+          name: "",
+          type: "bool",
+          internalType: "bool",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "lockTokenURI",
-      "type": "function",
-      "inputs": [
+      name: "lockTokenURI",
+      type: "function",
+      inputs: [
         {
-          "name": "tokenId",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "tokenId",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "maxTokenSupply",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "maxTokenSupply",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "memberMaxMintCount",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "memberMaxMintCount",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "uint8",
-          "internalType": "uint8"
-        }
+          name: "",
+          type: "uint8",
+          internalType: "uint8",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "mint",
-      "type": "function",
-      "inputs": [
+      name: "mint",
+      type: "function",
+      inputs: [
         {
-          "name": "amount",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "amount",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "outputs": [
+      outputs: [
         {
-          "name": "",
-          "type": "uint256[]",
-          "internalType": "uint256[]"
-        }
+          name: "",
+          type: "uint256[]",
+          internalType: "uint256[]",
+        },
       ],
-      "stateMutability": "payable"
+      stateMutability: "payable",
     },
     {
-      "name": "mintPrice",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "mintPrice",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "name",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "name",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "string",
-          "internalType": "string"
-        }
+          name: "",
+          type: "string",
+          internalType: "string",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "owner",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "owner",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "address",
-          "internalType": "address"
-        }
+          name: "",
+          type: "address",
+          internalType: "address",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "ownerOf",
-      "type": "function",
-      "inputs": [
+      name: "ownerOf",
+      type: "function",
+      inputs: [
         {
-          "name": "tokenId",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "tokenId",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "outputs": [
+      outputs: [
         {
-          "name": "",
-          "type": "address",
-          "internalType": "address"
-        }
+          name: "",
+          type: "address",
+          internalType: "address",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "publicMint",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "publicMint",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "bool",
-          "internalType": "bool"
-        }
+          name: "",
+          type: "bool",
+          internalType: "bool",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "redeemVoucher",
-      "type": "function",
-      "inputs": [
+      name: "redeemVoucher",
+      type: "function",
+      inputs: [
         {
-          "name": "amount",
-          "type": "uint256",
-          "internalType": "uint256"
+          name: "amount",
+          type: "uint256",
+          internalType: "uint256",
         },
         {
-          "name": "voucher",
-          "type": "tuple",
-          "components": [
+          name: "voucher",
+          type: "tuple",
+          components: [
             {
-              "name": "redeemerAddress",
-              "type": "address",
-              "internalType": "address"
+              name: "redeemerAddress",
+              type: "address",
+              internalType: "address",
             },
             {
-              "name": "expiration",
-              "type": "uint256",
-              "internalType": "uint256"
+              name: "expiration",
+              type: "uint256",
+              internalType: "uint256",
             },
             {
-              "name": "minPrice",
-              "type": "uint256",
-              "internalType": "uint256"
+              name: "minPrice",
+              type: "uint256",
+              internalType: "uint256",
             },
             {
-              "name": "tokenCount",
-              "type": "uint16",
-              "internalType": "uint16"
+              name: "tokenCount",
+              type: "uint16",
+              internalType: "uint16",
             },
             {
-              "name": "signature",
-              "type": "bytes",
-              "internalType": "bytes"
-            }
+              name: "signature",
+              type: "bytes",
+              internalType: "bytes",
+            },
           ],
-          "internalType": "struct BlankArt.BlankNFTVoucher"
-        }
+          internalType: "struct BlankArt.BlankNFTVoucher",
+        },
       ],
-      "outputs": [
+      outputs: [
         {
-          "name": "",
-          "type": "uint256[]",
-          "internalType": "uint256[]"
-        }
+          name: "",
+          type: "uint256[]",
+          internalType: "uint256[]",
+        },
       ],
-      "stateMutability": "payable"
+      stateMutability: "payable",
     },
     {
-      "name": "removeVoucherSigner",
-      "type": "function",
-      "inputs": [
+      name: "removeVoucherSigner",
+      type: "function",
+      inputs: [
         {
-          "name": "oldVoucherSigner",
-          "type": "address",
-          "internalType": "address"
-        }
+          name: "oldVoucherSigner",
+          type: "address",
+          internalType: "address",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "renounceOwnership",
-      "type": "function",
-      "inputs": [],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      name: "renounceOwnership",
+      type: "function",
+      inputs: [],
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "royaltyInfo",
-      "type": "function",
-      "inputs": [
+      name: "royaltyInfo",
+      type: "function",
+      inputs: [
         {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
+          name: "",
+          type: "uint256",
+          internalType: "uint256",
         },
         {
-          "name": "salePrice",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "salePrice",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "outputs": [
+      outputs: [
         {
-          "name": "receiver",
-          "type": "address",
-          "internalType": "address"
+          name: "receiver",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "royaltyAmount",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "royaltyAmount",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "safeTransferFrom",
-      "type": "function",
-      "inputs": [
+      name: "safeTransferFrom",
+      type: "function",
+      inputs: [
         {
-          "name": "from",
-          "type": "address",
-          "internalType": "address"
+          name: "from",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "to",
-          "type": "address",
-          "internalType": "address"
+          name: "to",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "tokenId",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "tokenId",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "safeTransferFrom",
-      "type": "function",
-      "inputs": [
+      name: "safeTransferFrom",
+      type: "function",
+      inputs: [
         {
-          "name": "from",
-          "type": "address",
-          "internalType": "address"
+          name: "from",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "to",
-          "type": "address",
-          "internalType": "address"
+          name: "to",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "tokenId",
-          "type": "uint256",
-          "internalType": "uint256"
+          name: "tokenId",
+          type: "uint256",
+          internalType: "uint256",
         },
         {
-          "name": "_data",
-          "type": "bytes",
-          "internalType": "bytes"
-        }
+          name: "_data",
+          type: "bytes",
+          internalType: "bytes",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "setApprovalForAll",
-      "type": "function",
-      "inputs": [
+      name: "setApprovalForAll",
+      type: "function",
+      inputs: [
         {
-          "name": "operator",
-          "type": "address",
-          "internalType": "address"
+          name: "operator",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "approved",
-          "type": "bool",
-          "internalType": "bool"
-        }
+          name: "approved",
+          type: "bool",
+          internalType: "bool",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "setDefaultRoyalty",
-      "type": "function",
-      "inputs": [
+      name: "setDefaultRoyalty",
+      type: "function",
+      inputs: [
         {
-          "name": "recipient",
-          "type": "address",
-          "internalType": "address"
+          name: "recipient",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "bps",
-          "type": "uint16",
-          "internalType": "uint16"
-        }
+          name: "bps",
+          type: "uint16",
+          internalType: "uint16",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "supportsInterface",
-      "type": "function",
-      "inputs": [
+      name: "supportsInterface",
+      type: "function",
+      inputs: [
         {
-          "name": "interfaceId",
-          "type": "bytes4",
-          "internalType": "bytes4"
-        }
+          name: "interfaceId",
+          type: "bytes4",
+          internalType: "bytes4",
+        },
       ],
-      "outputs": [
+      outputs: [
         {
-          "name": "",
-          "type": "bool",
-          "internalType": "bool"
-        }
+          name: "",
+          type: "bool",
+          internalType: "bool",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "symbol",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "symbol",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "string",
-          "internalType": "string"
-        }
+          name: "",
+          type: "string",
+          internalType: "string",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "toggleActivation",
-      "type": "function",
-      "inputs": [],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      name: "toggleActivation",
+      type: "function",
+      inputs: [],
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "togglePublicMint",
-      "type": "function",
-      "inputs": [],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      name: "togglePublicMint",
+      type: "function",
+      inputs: [],
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "tokenIndex",
-      "type": "function",
-      "inputs": [],
-      "outputs": [
+      name: "tokenIndex",
+      type: "function",
+      inputs: [],
+      outputs: [
         {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "tokenURI",
-      "type": "function",
-      "inputs": [
+      name: "tokenURI",
+      type: "function",
+      inputs: [
         {
-          "name": "tokenId",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "tokenId",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "outputs": [
+      outputs: [
         {
-          "name": "",
-          "type": "string",
-          "internalType": "string"
-        }
+          name: "",
+          type: "string",
+          internalType: "string",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "tokenURILocked",
-      "type": "function",
-      "inputs": [
+      name: "tokenURILocked",
+      type: "function",
+      inputs: [
         {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "outputs": [
+      outputs: [
         {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "stateMutability": "view"
+      stateMutability: "view",
     },
     {
-      "name": "transferFrom",
-      "type": "function",
-      "inputs": [
+      name: "transferFrom",
+      type: "function",
+      inputs: [
         {
-          "name": "from",
-          "type": "address",
-          "internalType": "address"
+          name: "from",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "to",
-          "type": "address",
-          "internalType": "address"
+          name: "to",
+          type: "address",
+          internalType: "address",
         },
         {
-          "name": "tokenId",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "tokenId",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "transferOwnership",
-      "type": "function",
-      "inputs": [
+      name: "transferOwnership",
+      type: "function",
+      inputs: [
         {
-          "name": "newOwner",
-          "type": "address",
-          "internalType": "address"
-        }
+          name: "newOwner",
+          type: "address",
+          internalType: "address",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "updateFoundationAddress",
-      "type": "function",
-      "inputs": [
+      name: "updateFoundationAddress",
+      type: "function",
+      inputs: [
         {
-          "name": "newFoundationAddress",
-          "type": "address",
-          "internalType": "address payable"
-        }
+          name: "newFoundationAddress",
+          type: "address",
+          internalType: "address payable",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "updateMaxMintCount",
-      "type": "function",
-      "inputs": [
+      name: "updateMaxMintCount",
+      type: "function",
+      inputs: [
         {
-          "name": "_maxMint",
-          "type": "uint8",
-          "internalType": "uint8"
-        }
+          name: "_maxMint",
+          type: "uint8",
+          internalType: "uint8",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "updateMintPrice",
-      "type": "function",
-      "inputs": [
+      name: "updateMintPrice",
+      type: "function",
+      inputs: [
         {
-          "name": "price",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
+          name: "price",
+          type: "uint256",
+          internalType: "uint256",
+        },
       ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
+      outputs: [],
+      stateMutability: "nonpayable",
     },
     {
-      "name": "withdraw",
-      "type": "function",
-      "inputs": [],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    }
-  ]
+      name: "withdraw",
+      type: "function",
+      inputs: [],
+      outputs: [],
+      stateMutability: "nonpayable",
+    },
+  ],
 };
 
 export default BlankArt;

--- a/lib/web3Connection.js
+++ b/lib/web3Connection.js
@@ -1,20 +1,31 @@
-import { ethers } from 'ethers';
+import { ethers } from "ethers";
 
-const web3Connection = async (expectedNetwork, onBadNetwork, onConnection) => {
-  await window.ethereum.enable()
-  const provider = new ethers.providers.Web3Provider(window.ethereum)
-  const network = await provider.getNetwork()
+const NETWORK_NAMES = {
+  1: "Ethereum Mainnet",
+  4: "Rinkeby Testnet",
+};
 
-  if (network.name !== expectedNetwork.toLowerCase()) {
-    onBadNetwork(`Wrong network. Please connect to the ${expectedNetwork} test network.`)
+const web3Connection = async (
+  expectedNetworkId,
+  onBadNetwork,
+  onConnection
+) => {
+  await window.ethereum.enable();
+  const provider = new ethers.providers.Web3Provider(window.ethereum);
+  const network = await provider.getNetwork();
+
+  if (network.chainId !== expectedNetworkId) {
+    onBadNetwork(
+      `Wrong network. Please connect to ${NETWORK_NAMES[expectedNetworkId]} and try again.`
+    );
     setTimeout(
-      () => web3Connection(expectedNetwork, onBadNetwork, onConnection), 
+      () => web3Connection(expectedNetworkId, onBadNetwork, onConnection),
       500
-    )
-    return
+    );
+    return;
   }
 
   onConnection(provider);
-}
+};
 
-export default web3Connection
+export default web3Connection;

--- a/pages/mint.jsx
+++ b/pages/mint.jsx
@@ -24,13 +24,11 @@ const BlankMinting = () => {
   const [mintAmount, setMintAmount] = useState(5)
   const [address, setAddress] = useState(null)
   
-  const connect = async () => {
-    web3Connection(BlankArt.network, setError, setProvider)
-  }
+  const connect = () => web3Connection(BlankArt.networkId, setError, setProvider)
     
   useEffect(() => { 
     if (!provider) return;
-     
+
     const loadVoucher = async() => {
       const recipient = provider.getSigner();
       const recipientAddress = await recipient.getAddress();
@@ -66,8 +64,6 @@ const BlankMinting = () => {
     setTx(null);
   
     const recipient = provider.getSigner();
-  
-    const amount = document.getElementById('mint-amount').value;
     
     const contractAddress = BlankArt.address;
   
@@ -78,7 +74,7 @@ const BlankMinting = () => {
     
     try {
       setPending(true);
-      const info = await signer.redeemVoucher(amount, voucher)
+      const info = await signer.redeemVoucher(mintAmount, voucher)
       console.log(info)
       setPending(info.hash)
       const receipt = await info.wait();
@@ -104,7 +100,7 @@ const BlankMinting = () => {
   
       <BlankLayout>
         <TWCenteredContent>
-          <div className="mb-36 max-w-lg text-center">
+          <div className="max-w-lg text-center mb-36">
             {nfts.length > 0 &&
               <div>You have NFTs!</div>
             }
@@ -120,22 +116,18 @@ const BlankMinting = () => {
             }
             {voucher && !pending && !tx &&
               <div>
-                <h1 className='text-2xl mb-12'>Mint</h1>
+                <h1 className='mb-12 text-2xl'>Mint</h1>
                 <p className='mb-6'>Congratulations, you have been approved to mint!</p>
                 <p className='mb-6'>How many Blank NFTs would you like to mint?</p>
                 <p className='mb-6'>You can only mint once.</p>
                 <p>
                   <select 
                     id="mint-amount" 
-                    defaultValue="5"
-                    className='cursor-pointer border text-xl p-3 rounded-xl'
+                    defaultValue={mintAmount}
+                    className='p-3 text-xl border cursor-pointer rounded-xl'
                     onChange={(e) => setMintAmount(e.target.value)}
                   >
-                    <option value="1">1</option>
-                    <option value="2">2</option>
-                    <option value="3">3</option>
-                    <option value="4">4</option>
-                    <option value="5">5</option>
+                    {Array(5).fill(0).map((_, i)=> (<option key={i+1} value={i+1}>{i+1}</option>))}
                   </select>
                 </p>
                 <p>
@@ -152,7 +144,7 @@ const BlankMinting = () => {
             }
             {pending && !tx &&
               <div>
-                <h1 className='text-2xl mb-12'>Minting...</h1>
+                <h1 className='mb-12 text-2xl'>Minting...</h1>
                 <p>Please wait, this may take a few minutes.</p>
                 {typeof pending === 'string' &&
                   <p>
@@ -169,7 +161,7 @@ const BlankMinting = () => {
             }
             {tx &&
               <div>
-                <h1 className='text-2xl mb-12'>Minted!</h1>
+                <h1 className='mb-12 text-2xl'>Minted!</h1>
                 <p>
                   You can see your minted transaction on&nbsp;
                   {address &&
@@ -193,7 +185,7 @@ const BlankMinting = () => {
               </div>
             }
             {error && !pending &&
-              <div className='text-red-800 text-lg my-6'>
+              <div className='my-6 text-lg text-red-800'>
                 {error}
               </div>
             }


### PR DESCRIPTION
- expected network is now not determined by its slug (name) but rather by it's ID, this doesn't only feel better, but the IDs cannot ever change while the names could actually change.
- set networkId to 1 for ethereum mainnet and added NETWORK_NAMES constant to mint page. 
- refactored mint page a bit, "mintAmount" state was never used but it was changed